### PR TITLE
🔧 Adjust CIBW_SKIP handling in PyPI publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -85,9 +85,10 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.23.0
       env:
-        CIBW_SKIP: ${{ env.CIBW_SKIP }}
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos }}
+        if: github.event_name == 'pull_request'
+        CIBW_SKIP: ${{ env.CIBW_SKIP }}
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Update the handling of the CIBW_SKIP environment variable to ensure it is set correctly during pull request events in the PyPI publish workflow. This change improves the workflow's behavior when building wheels for pull requests.